### PR TITLE
Add book functionality, and local storage persistance to handle add book

### DIFF
--- a/components/AddBook.tsx
+++ b/components/AddBook.tsx
@@ -1,0 +1,178 @@
+"use client";
+
+import React, { useEffect, useState } from 'react';
+import {
+    Button,
+    Dialog,
+    DialogActions,
+    DialogContent,
+    DialogTitle,
+    TextField,
+    MenuItem,
+    Select,
+    FormControl,
+    InputLabel,
+    Checkbox,
+    ListItemText,
+    OutlinedInput,
+} from '@mui/material';
+import { Book, Category, Tag } from '../interfaces/Book';
+
+interface AddBookProps {
+    isOpen: boolean;
+    onClose: () => void;
+    onAddBook: (book: Book) => void;
+    categories: Category[];
+    tags: Tag[];
+    nextId: number;
+}
+
+const AddBook: React.FC<AddBookProps> = ({ isOpen, onClose, onAddBook, categories, tags, nextId }) => {
+    const [newBook, setNewBook] = useState({
+        title: '',
+        author: '',
+        genre: '',
+        rating: 0,
+        categories: [] as number[],
+        tags: [] as number[],
+    });
+    const [isFormValid, setIsFormValid] = useState(false);
+
+    useEffect(() => {
+        const { title, author, genre, rating } = newBook;
+        setIsFormValid(title.trim() !== '' && author.trim() !== '' && genre.trim() !== '' && rating >= 0 && rating <= 5);
+    }, [newBook]);
+
+    const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        const { name, value } = e.target;
+
+        let updatedValue: string | number = value;
+
+        if (name === 'rating') {
+            const ratingValue = parseFloat(value);
+            if (ratingValue < 0) {
+                updatedValue = 0;
+            } else if (ratingValue > 5) {
+                updatedValue = 5;
+            } else {
+                updatedValue = ratingValue;
+            }
+        }
+        setNewBook({
+            ...newBook,
+            [name]: updatedValue,
+        });
+    };
+
+    const handleMultiSelectChange = (name: string, values: number[]) => {
+        setNewBook({
+            ...newBook,
+            [name]: values,
+        });
+    };
+
+    const handleSubmit = () => {
+        if (isFormValid) {
+            onAddBook({ ...newBook, id: nextId });
+            setNewBook({
+                title: '',
+                author: '',
+                genre: '',
+                rating: 0,
+                categories: [] as number[],
+                tags: [] as number[],
+            });
+            onClose();
+        }
+    };
+
+    return (
+        <Dialog open={isOpen} onClose={onClose}>
+            <DialogTitle>Add New Book</DialogTitle>
+            <DialogContent>
+                <TextField
+                    margin="dense"
+                    label="Title"
+                    name="title"
+                    value={newBook.title}
+                    onChange={handleInputChange}
+                    fullWidth
+                    required
+                />
+                <TextField
+                    margin="dense"
+                    label="Author"
+                    name="author"
+                    value={newBook.author}
+                    onChange={handleInputChange}
+                    fullWidth
+                    required
+                />
+                <TextField
+                    margin="dense"
+                    label="Genre"
+                    name="genre"
+                    value={newBook.genre}
+                    onChange={handleInputChange}
+                    fullWidth
+                    required
+                />
+                <TextField
+                    margin="dense"
+                    label="Personal Rating"
+                    name="rating"
+                    type="number"
+                    value={newBook.rating}
+                    onChange={handleInputChange}
+                    fullWidth
+                    inputProps={{ min: 0, max: 5 }}
+                    required
+                />
+                <FormControl fullWidth margin="dense">
+                    <InputLabel>Categories</InputLabel>
+                    <Select
+                        multiple
+                        value={newBook.categories}
+                        onChange={(e) => handleMultiSelectChange('categories', e.target.value as number[])}
+                        input={<OutlinedInput label="Categories" />}
+                        renderValue={(selected) => (selected as number[]).map(id => categories.find(category => category.id === id.toString())?.name).join(', ')}
+                    >
+                        {categories.map(category => (
+                            <MenuItem key={category.id} value={parseInt(category.id)}>
+                                <Checkbox checked={newBook.categories.indexOf(parseInt(category.id)) > -1} />
+                                <ListItemText primary={category.name} />
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+                <FormControl fullWidth margin="dense">
+                    <InputLabel>Tags</InputLabel>
+                    <Select
+                        multiple
+                        value={newBook.tags}
+                        onChange={(e) => handleMultiSelectChange('tags', e.target.value as number[])}
+                        input={<OutlinedInput label="Tags" />}
+                        renderValue={(selected) => (selected as number[]).map(id => tags.find(tag => tag.id === id.toString())?.name).join(', ')}
+                    >
+                        {tags.map(tag => (
+                            <MenuItem key={tag.id} value={parseInt(tag.id)}>
+                                <Checkbox checked={newBook.tags.indexOf(parseInt(tag.id)) > -1} />
+                                <ListItemText primary={tag.name} />
+                            </MenuItem>
+                        ))}
+                    </Select>
+                </FormControl>
+            </DialogContent>
+            <DialogActions>
+                <Button onClick={onClose} color="primary">
+                    Cancel
+                </Button>
+                <Button onClick={handleSubmit} color="primary" disabled={!isFormValid}>
+                    Add Book
+                </Button>
+            </DialogActions>
+        </Dialog>
+    );
+};
+
+export default AddBook;

--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -1,9 +1,9 @@
-
 "use client";
 
 import React, { useEffect, useState } from 'react';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { Container } from '@mui/material';
+import { Container, Button } from '@mui/material';
+import AddBook from './AddBook';
 import { Book, Category, Tag } from '../interfaces/Book';
 
 const columns: GridColDef[] = [
@@ -15,21 +15,29 @@ const columns: GridColDef[] = [
   { field: 'tags', headerName: 'Tags', width: 200 },
 ];
 
-const BookListTable: React.FC = () => {
+const BookList: React.FC = () => {
   const [books, setBooks] = useState<Book[]>([]);
   const [categories, setCategories] = useState<Category[]>([]);
   const [tags, setTags] = useState<Tag[]>([]);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   useEffect(() => {
     const fetchData = async () => {
       const response = await fetch('/books.json');
       const data = await response.json();
-      setBooks(data.books);
       setCategories(data.categories);
       setTags(data.tags);
+
+      const storedBooks = localStorage.getItem('books');
+      if (storedBooks) {
+        setBooks(JSON.parse(storedBooks));
+      } else {
+        setBooks(data.books);
+      }
     };
     fetchData();
-  }, []); 
+  }, []);
+
 
   const getCategoryNames = (ids: number[]) => {
     return ids.map(id => categories.find(category => category.id === id.toString())?.name).join(', ');
@@ -45,6 +53,20 @@ const BookListTable: React.FC = () => {
     tags: getTagNames(book.tags)
   }));
 
+  const handleOpenModal = () => {
+    setIsModalOpen(true);
+  };
+
+  const handleCloseModal = () => {
+    setIsModalOpen(false);
+  };
+
+  const handleAddBook = (newBook: Book) => {
+    const updatedBooks = [...books, newBook];
+    setBooks([...books, newBook]);
+    localStorage.setItem('books', JSON.stringify(updatedBooks));
+  };
+
   return (
     <Container>
       <div style={{ height: 400, width: '100%' }}>
@@ -59,8 +81,19 @@ const BookListTable: React.FC = () => {
           }}
         />
       </div>
+      <Button variant="contained" color="primary" onClick={handleOpenModal} style={{ marginTop: 20 }}>
+        Add Book
+      </Button>
+      <AddBook
+        isOpen={isModalOpen}
+        onClose={handleCloseModal}
+        onAddBook={handleAddBook}
+        categories={categories}
+        tags={tags}
+        nextId={books.length + 1}
+      />
     </Container>
   );
 };
 
-export default BookListTable;
+export default BookList;


### PR DESCRIPTION
- "Add" Functionality was added
- Added in all form control checks, making sure required fields are hit, and not allowing users to input ratings below 0, and above 5 with handleinput check.
- Added Local storage, the main reason for this was to avoid setting up a backend to have new books persist. The initial idea is to add it directly to the JSON, however we can sort of cheat the system here a little bit, by having the initial load useEffect check if there's anything in storage, if there is, we just use what's in there, if not, then we just use the JSON. 


TODO

- Edit
- Delete
- Add/Edit/Delete for categories and tags (similar functionality overall though)
- Adding Toastr for User Feedback and Error States
- Swapping entirely out of the JSON approach, and using the FakerAPI to prepopulate initially, and checking based on that