### PR TITLE
Adding delete and Edit functionality

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,12 +5,12 @@ import BookList from '../components/BookList';
 import { CssBaseline } from '@mui/material';
 
 const Home: React.FC = () => {
-  return (
-    <>
-      <CssBaseline />
-      <BookList />
-    </>
-  );
+    return (
+        <>
+            <CssBaseline />
+            <BookList />
+        </>
+    );
 };
 
 export default Home;

--- a/components/Actions.tsx
+++ b/components/Actions.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { IconButton } from '@mui/material';
+import EditIcon from '@mui/icons-material/Edit';
+import DeleteIcon from '@mui/icons-material/Delete';
+
+interface ActionsProps {
+    bookId: number;
+    onEdit: (bookId: number) => void;
+    onDelete: (bookId: number) => void;
+}
+
+const Actions: React.FC<ActionsProps> = ({ bookId, onEdit, onDelete }) => {
+    return (
+        <div>
+            <IconButton onClick={() => onEdit(bookId)}>
+                <EditIcon />
+            </IconButton>
+            <IconButton onClick={() => onDelete(bookId)}>
+                <DeleteIcon />
+            </IconButton>
+        </div>
+    );
+};
+
+export default Actions;

--- a/components/BookList.tsx
+++ b/components/BookList.tsx
@@ -2,98 +2,176 @@
 
 import React, { useEffect, useState } from 'react';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
-import { Container, Button } from '@mui/material';
+import { Container, Button, Dialog, DialogActions, DialogContent, DialogTitle } from '@mui/material';
 import AddBook from './AddBook';
+import EditBook from './EditBook';
 import { Book, Category, Tag } from '../interfaces/Book';
-
-const columns: GridColDef[] = [
-  { field: 'title', headerName: 'Title', width: 150 },
-  { field: 'author', headerName: 'Author', width: 150 },
-  { field: 'genre', headerName: 'Genre', width: 150 },
-  { field: 'rating', headerName: 'Personal Rating', width: 150, type: 'number' },
-  { field: 'categories', headerName: 'Categories', width: 200 },
-  { field: 'tags', headerName: 'Tags', width: 200 },
-];
+import Actions from './Actions';
 
 const BookList: React.FC = () => {
-  const [books, setBooks] = useState<Book[]>([]);
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [tags, setTags] = useState<Tag[]>([]);
-  const [isModalOpen, setIsModalOpen] = useState(false);
+    const [books, setBooks] = useState<Book[]>([]);
+    const [categories, setCategories] = useState<Category[]>([]);
+    const [tags, setTags] = useState<Tag[]>([]);
+    const [isAddModalOpen, setIsAddModalOpen] = useState(false);
+    const [isEditModalOpen, setIsEditModalOpen] = useState(false);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const [bookToDelete, setBookToDelete] = useState<Book | null>(null);
+    const [bookToEdit, setBookToEdit] = useState<Book | null>(null);
 
-  useEffect(() => {
-    const fetchData = async () => {
-      const response = await fetch('/books.json');
-      const data = await response.json();
-      setCategories(data.categories);
-      setTags(data.tags);
+    useEffect(() => {
+        const fetchData = async () => {
+            const response = await fetch('/books.json');
+            const data = await response.json();
+            setCategories(data.categories);
+            setTags(data.tags);
 
-      const storedBooks = localStorage.getItem('books');
-      if (storedBooks) {
-        setBooks(JSON.parse(storedBooks));
-      } else {
-        setBooks(data.books);
-      }
+            const storedBooks = localStorage.getItem('books');
+            if (storedBooks) {
+                setBooks(JSON.parse(storedBooks));
+            } else {
+                setBooks(data.books);
+            }
+        };
+        fetchData();
+    }, []);
+
+    const getCategoryNames = (ids: number[]) => {
+        return ids.map(id => categories.find(category => category.id === id.toString())?.name).join(', ');
     };
-    fetchData();
-  }, []);
 
+    const getTagNames = (ids: number[]) => {
+        return ids.map(id => tags.find(tag => tag.id === id.toString())?.name).join(', ');
+    };
 
-  const getCategoryNames = (ids: number[]) => {
-    return ids.map(id => categories.find(category => category.id === id.toString())?.name).join(', ');
-  };
+    const rows = books.map(book => ({
+        ...book,
+        categories: getCategoryNames(book.categories),
+        tags: getTagNames(book.tags)
+    }));
 
-  const getTagNames = (ids: number[]) => {
-    return ids.map(id => tags.find(tag => tag.id === id.toString())?.name).join(', ');
-  };
+    const handleOpenAddModal = () => {
+        setIsAddModalOpen(true);
+    };
 
-  const rows = books.map(book => ({
-    ...book,
-    categories: getCategoryNames(book.categories),
-    tags: getTagNames(book.tags)
-  }));
+    const handleOpenEditModal = (bookId: number) => {
+        const book = books.find(book => book.id === bookId);
+        if (book) {
+            setBookToEdit(book);
+            setIsEditModalOpen(true);
+            console.log("Editing book:", book);
+        }
+    };
 
-  const handleOpenModal = () => {
-    setIsModalOpen(true);
-  };
+    const handleOpenDeleteModal = (bookId: number) => {
+        const book = books.find(book => book.id === bookId);
+        if (book) {
+            setBookToDelete(book);
+            setIsDeleteModalOpen(true);
+        }
+    };
 
-  const handleCloseModal = () => {
-    setIsModalOpen(false);
-  };
+    const handleCloseModal = () => {
+        setIsAddModalOpen(false);
+        setIsEditModalOpen(false);
+        setIsDeleteModalOpen(false);
+        setBookToDelete(null);
+        setBookToEdit(null);
+    };
 
-  const handleAddBook = (newBook: Book) => {
-    const updatedBooks = [...books, newBook];
-    setBooks([...books, newBook]);
-    localStorage.setItem('books', JSON.stringify(updatedBooks));
-  };
+    const handleDeleteBook = () => {
+        if (bookToDelete) {
+            const updatedBooks = books.filter(book => book.id !== bookToDelete.id);
+            setBooks(updatedBooks);
+            localStorage.setItem('books', JSON.stringify(updatedBooks));
+            handleCloseModal();
+        }
+    };
 
-  return (
-    <Container>
-      <div style={{ height: 400, width: '100%' }}>
-        <DataGrid
-          rows={rows}
-          columns={columns}
-          pageSizeOptions={[5]}
-          initialState={{
-            pagination: {
-              paginationModel: { pageSize: 5, page: 0 },
-            },
-          }}
-        />
-      </div>
-      <Button variant="contained" color="primary" onClick={handleOpenModal} style={{ marginTop: 20 }}>
-        Add Book
-      </Button>
-      <AddBook
-        isOpen={isModalOpen}
-        onClose={handleCloseModal}
-        onAddBook={handleAddBook}
-        categories={categories}
-        tags={tags}
-        nextId={books.length + 1}
-      />
-    </Container>
-  );
+    const handleAddBook = (newBook: Book) => {
+        const updatedBooks = [...books, newBook];
+        setBooks(updatedBooks);
+        localStorage.setItem('books', JSON.stringify(updatedBooks));
+    };
+
+    const handleEditBook = (updatedBook: Book) => {
+        const updatedBooks = books.map(book => (book.id === updatedBook.id ? updatedBook : book));
+        setBooks(updatedBooks);
+        localStorage.setItem('books', JSON.stringify(updatedBooks));
+        handleCloseModal();
+    };
+
+    const columns: GridColDef[] = [
+        { field: 'title', headerName: 'Title', width: 150 },
+        { field: 'author', headerName: 'Author', width: 150 },
+        { field: 'genre', headerName: 'Genre', width: 150 },
+        { field: 'rating', headerName: 'Personal Rating', width: 150, type: 'number' },
+        { field: 'categories', headerName: 'Categories', width: 200 },
+        { field: 'tags', headerName: 'Tags', width: 200 },
+        {
+            field: 'actions',
+            headerName: 'Actions',
+            width: 150,
+            renderCell: (params) => (
+                <Actions
+                    bookId={params.row.id}
+                    onEdit={handleOpenEditModal}
+                    onDelete={handleOpenDeleteModal}
+                />
+            ),
+        },
+    ];
+
+    return (
+        <Container>
+            <div style={{ height: 400, width: '100%' }}>
+                <DataGrid
+                    rows={rows}
+                    columns={columns}
+                    pageSizeOptions={[5]}
+                    initialState={{
+                        pagination: {
+                            paginationModel: { pageSize: 5, page: 0 },
+                        },
+                    }}
+                />
+            </div>
+            <Button variant="contained" color="primary" onClick={handleOpenAddModal} style={{ marginTop: 20 }}>
+                Add Book
+            </Button>
+            <AddBook
+                isOpen={isAddModalOpen}
+                onClose={handleCloseModal}
+                onAddBook={handleAddBook}
+                categories={categories}
+                tags={tags}
+                nextId={books.length + 1}
+            />
+            {bookToEdit && (
+                <EditBook
+                    isOpen={isEditModalOpen}
+                    onClose={handleCloseModal}
+                    onEditBook={handleEditBook}
+                    categories={categories}
+                    tags={tags}
+                    initialBook={bookToEdit}
+                />
+            )}
+            <Dialog open={isDeleteModalOpen} onClose={handleCloseModal}>
+                <DialogTitle>Confirm Delete</DialogTitle>
+                <DialogContent>
+                    Are you sure you want to delete this book?
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleCloseModal} color="primary">
+                        Cancel
+                    </Button>
+                    <Button onClick={handleDeleteBook} color="secondary">
+                        Delete
+                    </Button>
+                </DialogActions>
+            </Dialog>
+        </Container>
+    );
 };
 
 export default BookList;

--- a/components/EditBook.tsx
+++ b/components/EditBook.tsx
@@ -1,37 +1,32 @@
-"use client";
-
-import React, { useEffect, useState } from 'react';
-import { Button, Dialog, DialogActions, DialogContent, DialogTitle, TextField, MenuItem, Select, FormControl, InputLabel, Checkbox, ListItemText, OutlinedInput } from '@mui/material';
+import React, { useState, useEffect } from 'react';
+import { Dialog, DialogActions, DialogContent, DialogTitle, TextField, MenuItem, Select, FormControl, InputLabel, Checkbox, ListItemText, OutlinedInput, Button } from '@mui/material';
 import { Book, Category, Tag } from '../interfaces/Book';
 
-interface AddBookProps {
+
+interface EditBookProps {
     isOpen: boolean;
     onClose: () => void;
-    onAddBook: (book: Book) => void;
+    onEditBook: (book: Book) => void;
     categories: Category[];
     tags: Tag[];
-    nextId: number;
+    initialBook: Book;
 }
 
-const AddBook: React.FC<AddBookProps> = ({ isOpen, onClose, onAddBook, categories, tags, nextId }) => {
-    const [newBook, setNewBook] = useState({
-        title: '',
-        author: '',
-        genre: '',
-        rating: 0,
-        categories: [] as number[],
-        tags: [] as number[],
-    });
+const EditBook: React.FC<EditBookProps> = ({ isOpen, onClose, onEditBook, categories, tags, initialBook }) => {
+    const [book, setBook] = useState<Book>(initialBook);
     const [isFormValid, setIsFormValid] = useState(false);
 
     useEffect(() => {
-        const { title, author, genre, rating } = newBook;
+        setBook(initialBook);
+    }, [initialBook]);
+
+    useEffect(() => {
+        const { title, author, genre, rating } = book;
         setIsFormValid(title.trim() !== '' && author.trim() !== '' && genre.trim() !== '' && rating >= 0 && rating <= 5);
-    }, [newBook]);
+    }, [book]);
 
     const handleInputChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         const { name, value } = e.target;
-
         let updatedValue: string | number = value;
 
         if (name === 'rating') {
@@ -44,43 +39,36 @@ const AddBook: React.FC<AddBookProps> = ({ isOpen, onClose, onAddBook, categorie
                 updatedValue = ratingValue;
             }
         }
-        setNewBook({
-            ...newBook,
+
+        setBook({
+            ...book,
             [name]: updatedValue,
         });
     };
 
     const handleMultiSelectChange = (name: string, values: number[]) => {
-        setNewBook({
-            ...newBook,
+        setBook({
+            ...book,
             [name]: values,
         });
     };
 
     const handleSubmit = () => {
         if (isFormValid) {
-            onAddBook({ ...newBook, id: nextId });
-            setNewBook({
-                title: '',
-                author: '',
-                genre: '',
-                rating: 0,
-                categories: [] as number[],
-                tags: [] as number[],
-            });
+            onEditBook(book);
             onClose();
         }
     };
 
     return (
         <Dialog open={isOpen} onClose={onClose}>
-            <DialogTitle>Add New Book</DialogTitle>
+            <DialogTitle>Edit Book</DialogTitle>
             <DialogContent>
                 <TextField
                     margin="dense"
                     label="Title"
                     name="title"
-                    value={newBook.title}
+                    value={book.title}
                     onChange={handleInputChange}
                     fullWidth
                     required
@@ -89,7 +77,7 @@ const AddBook: React.FC<AddBookProps> = ({ isOpen, onClose, onAddBook, categorie
                     margin="dense"
                     label="Author"
                     name="author"
-                    value={newBook.author}
+                    value={book.author}
                     onChange={handleInputChange}
                     fullWidth
                     required
@@ -98,7 +86,7 @@ const AddBook: React.FC<AddBookProps> = ({ isOpen, onClose, onAddBook, categorie
                     margin="dense"
                     label="Genre"
                     name="genre"
-                    value={newBook.genre}
+                    value={book.genre}
                     onChange={handleInputChange}
                     fullWidth
                     required
@@ -108,7 +96,7 @@ const AddBook: React.FC<AddBookProps> = ({ isOpen, onClose, onAddBook, categorie
                     label="Personal Rating"
                     name="rating"
                     type="number"
-                    value={newBook.rating}
+                    value={book.rating}
                     onChange={handleInputChange}
                     fullWidth
                     inputProps={{ min: 0, max: 5 }}
@@ -118,14 +106,14 @@ const AddBook: React.FC<AddBookProps> = ({ isOpen, onClose, onAddBook, categorie
                     <InputLabel>Categories</InputLabel>
                     <Select
                         multiple
-                        value={newBook.categories}
+                        value={book.categories}
                         onChange={(e) => handleMultiSelectChange('categories', e.target.value as number[])}
                         input={<OutlinedInput label="Categories" />}
                         renderValue={(selected) => (selected as number[]).map(id => categories.find(category => category.id === id.toString())?.name).join(', ')}
                     >
                         {categories.map(category => (
                             <MenuItem key={category.id} value={parseInt(category.id)}>
-                                <Checkbox checked={newBook.categories.indexOf(parseInt(category.id)) > -1} />
+                                <Checkbox checked={book.categories.includes(parseInt(category.id))} />
                                 <ListItemText primary={category.name} />
                             </MenuItem>
                         ))}
@@ -135,14 +123,14 @@ const AddBook: React.FC<AddBookProps> = ({ isOpen, onClose, onAddBook, categorie
                     <InputLabel>Tags</InputLabel>
                     <Select
                         multiple
-                        value={newBook.tags}
+                        value={book.tags}
                         onChange={(e) => handleMultiSelectChange('tags', e.target.value as number[])}
                         input={<OutlinedInput label="Tags" />}
                         renderValue={(selected) => (selected as number[]).map(id => tags.find(tag => tag.id === id.toString())?.name).join(', ')}
                     >
                         {tags.map(tag => (
                             <MenuItem key={tag.id} value={parseInt(tag.id)}>
-                                <Checkbox checked={newBook.tags.indexOf(parseInt(tag.id)) > -1} />
+                                <Checkbox checked={book.tags.includes(parseInt(tag.id))} />
                                 <ListItemText primary={tag.name} />
                             </MenuItem>
                         ))}
@@ -154,11 +142,11 @@ const AddBook: React.FC<AddBookProps> = ({ isOpen, onClose, onAddBook, categorie
                     Cancel
                 </Button>
                 <Button onClick={handleSubmit} color="primary" disabled={!isFormValid}>
-                    Add Book
+                    Save Changes
                 </Button>
             </DialogActions>
         </Dialog>
     );
 };
 
-export default AddBook;
+export default EditBook;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
+        "@mui/icons-material": "^5.15.19",
         "@mui/material": "^5.15.19",
         "@mui/x-data-grid": "^7.6.2",
         "next": "14.2.3",
@@ -674,6 +675,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.15.19",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.15.19.tgz",
+      "integrity": "sha512-RsEiRxA5azN9b8gI7JRqekkgvxQUlitoBOtZglflb8cUDyP12/cP4gRwhb44Ea1/zwwGGjAj66ZJpGHhKfibNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
+    "@mui/icons-material": "^5.15.19",
     "@mui/material": "^5.15.19",
     "@mui/x-data-grid": "^7.6.2",
     "next": "14.2.3",


### PR DESCRIPTION
- Added Edit and Delete
- Utilized RenderCell and consolidated both of these to be held within the Action component. This is to keep it cleaner, and RenderCell allows us to just return components directly in DataGrids

Ran into a few issues with Edit:

- Had problem with how I was returning data, initially tried to return based off context in the DataGrid, but was not mapping it correctly back to the books category id/tag id. Went with simpler approach of bringing it directly to the books, and returning that way. 
- Reused almost all logic from Add after fixing this issue.

TODO:

- Tag/Category - Add/edit/delete (similar if not the same functionality as this)
- Styling, making it look prettier
- Hosting
- Toastr
- API support from fakerAPI